### PR TITLE
fix: Actualización de correlativas

### DIFF
--- a/public/data/careers/Ing en sistemas UTN.json
+++ b/public/data/careers/Ing en sistemas UTN.json
@@ -214,7 +214,7 @@
         "description": "",
         "correlativities": {
           "regularized": [
-            16
+            10
           ],
           "approved": [
             2,

--- a/public/data/careers/Ing en sistemas UTN.json
+++ b/public/data/careers/Ing en sistemas UTN.json
@@ -1,908 +1,786 @@
 {
-  "title": "Ing en sistemas UTN",
-  "author": "Nicolas Dembrowky",
-  "years": 5,
-  "creationDate": "2025-01-15T12:00:00.000Z",
-  "lastUpdateDate": "2025-01-26T18:33:16.973Z",
-  "subjects": [
-    {
-      "sid": 1,
-      "index": 0,
-      "info": {
-        "name": "Sistemas y Procesos de Negocio",
-        "altname": "SyPN",
-        "duration": 1,
-        "modality": 0,
-        "weeklyLoad": 3,
-        "year": 1,
-        "description": "",
-        "correlativities": {
-          "regularized": [],
-          "approved": []
+    "title": "Ing en sistemas UTN",
+    "author": "Nicolas Dembrowky",
+    "years": 5,
+    "creationDate": "2025-01-15T12:00:00.000Z",
+    "lastUpdateDate": "2025-01-26T18:33:16.973Z",
+    "subjects": [
+        {
+            "sid": 1,
+            "index": 0,
+            "info": {
+                "name": "Sistemas y Procesos de Negocio",
+                "altname": "SyPN",
+                "duration": 1,
+                "modality": 0,
+                "weeklyLoad": 3,
+                "year": 1,
+                "description": "",
+                "correlativities": {
+                    "regularized": [],
+                    "approved": []
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
+        },
+        {
+            "sid": 9,
+            "index": 0,
+            "info": {
+                "name": "Analisis de Sistemas de Informacion",
+                "altname": "ASI",
+                "duration": 1,
+                "modality": 0,
+                "weeklyLoad": 6,
+                "year": 2,
+                "description": "",
+                "correlativities": {
+                    "regularized": [1, 4],
+                    "approved": []
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
+        },
+        {
+            "sid": 17,
+            "index": 0,
+            "info": {
+                "name": "Diseño de Sistemas de Informacion",
+                "altname": "DSI",
+                "duration": 1,
+                "modality": 0,
+                "weeklyLoad": 6,
+                "year": 3,
+                "description": "",
+                "correlativities": {
+                    "regularized": [9, 12],
+                    "approved": [13, 4, 1]
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
+        },
+        {
+            "sid": 25,
+            "index": 0,
+            "info": {
+                "name": "Administracion de Sistemas de Informacion",
+                "altname": "AdmSI",
+                "duration": 1,
+                "modality": 0,
+                "weeklyLoad": 6,
+                "year": 4,
+                "description": "",
+                "correlativities": {
+                    "regularized": [19, 17],
+                    "approved": [9]
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
+        },
+        {
+            "sid": 33,
+            "index": 0,
+            "info": {
+                "name": "Proyecto Final",
+                "altname": "PF",
+                "duration": 1,
+                "modality": 0,
+                "weeklyLoad": 6,
+                "year": 5,
+                "description": "",
+                "correlativities": {
+                    "regularized": [27, 25, 24],
+                    "approved": [18, 20, 17]
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
+        },
+        {
+            "sid": 2,
+            "index": 1,
+            "info": {
+                "name": "Analisis Matematico 1",
+                "altname": "AM1",
+                "duration": 1,
+                "modality": 0,
+                "weeklyLoad": 5,
+                "year": 1,
+                "description": "",
+                "correlativities": {
+                    "regularized": [],
+                    "approved": []
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
+        },
+        {
+            "sid": 10,
+            "index": 1,
+            "info": {
+                "name": "Analisis Matematico 2",
+                "altname": "AM2",
+                "duration": 1,
+                "modality": 0,
+                "weeklyLoad": 5,
+                "year": 2,
+                "description": "",
+                "correlativities": {
+                    "regularized": [2, 6],
+                    "approved": []
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
+        },
+        {
+            "sid": 18,
+            "index": 1,
+            "info": {
+                "name": "Ingles 2",
+                "altname": "IT2",
+                "duration": 1,
+                "modality": 0,
+                "weeklyLoad": 2,
+                "year": 3,
+                "description": "",
+                "correlativities": {
+                    "regularized": [13],
+                    "approved": []
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
+        },
+        {
+            "sid": 26,
+            "index": 1,
+            "info": {
+                "name": "Analisis Numerico",
+                "altname": "AN",
+                "duration": 0,
+                "modality": 0,
+                "weeklyLoad": 6,
+                "year": 4,
+                "description": "",
+                "correlativities": {
+                    "regularized": [10],
+                    "approved": [2, 6]
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
+        },
+        {
+            "sid": 34,
+            "index": 1,
+            "info": {
+                "name": "Inteligencia Artificial",
+                "altname": "IA",
+                "duration": 0,
+                "modality": 0,
+                "weeklyLoad": 6,
+                "year": 5,
+                "description": "",
+                "correlativities": {
+                    "regularized": [28],
+                    "approved": [16, 26]
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
+        },
+        {
+            "sid": 3,
+            "index": 2,
+            "info": {
+                "name": "Logica y Estructuras Discretas",
+                "altname": "LyED",
+                "duration": 1,
+                "modality": 0,
+                "weeklyLoad": 3,
+                "year": 1,
+                "description": "",
+                "correlativities": {
+                    "regularized": [],
+                    "approved": []
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
+        },
+        {
+            "sid": 11,
+            "index": 2,
+            "info": {
+                "name": "Sintaxis y Semantica de los Lenguajes",
+                "altname": "SySL",
+                "duration": 1,
+                "modality": 0,
+                "weeklyLoad": 4,
+                "year": 2,
+                "description": "",
+                "correlativities": {
+                    "regularized": [3, 4],
+                    "approved": []
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
+        },
+        {
+            "sid": 19,
+            "index": 2,
+            "info": {
+                "name": "Economia",
+                "altname": "ECO",
+                "duration": 0,
+                "modality": 0,
+                "weeklyLoad": 6,
+                "year": 3,
+                "description": "",
+                "correlativities": {
+                    "regularized": [],
+                    "approved": [2, 6]
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
+        },
+        {
+            "sid": 27,
+            "index": 2,
+            "info": {
+                "name": "Ingenieria y Calidad de Software",
+                "altname": "IyCS",
+                "duration": 0,
+                "modality": 0,
+                "weeklyLoad": 6,
+                "year": 4,
+                "description": "",
+                "correlativities": {
+                    "regularized": [21, 20, 17],
+                    "approved": [11, 12]
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
+        },
+        {
+            "sid": 35,
+            "index": 2,
+            "info": {
+                "name": "Gestion Gerencial",
+                "altname": "GC",
+                "duration": 0,
+                "modality": 0,
+                "weeklyLoad": 6,
+                "year": 5,
+                "description": "",
+                "correlativities": {
+                    "regularized": [29, 25],
+                    "approved": [19]
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
+        },
+        {
+            "sid": 4,
+            "index": 3,
+            "info": {
+                "name": "Algoritmos y Estructuras de Datos",
+                "altname": "AyED",
+                "duration": 1,
+                "modality": 0,
+                "weeklyLoad": 5,
+                "year": 1,
+                "description": "",
+                "correlativities": {
+                    "regularized": [],
+                    "approved": []
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
+        },
+        {
+            "sid": 12,
+            "index": 3,
+            "info": {
+                "name": "Paradigmas de Programacion",
+                "altname": "PdP",
+                "duration": 1,
+                "modality": 0,
+                "weeklyLoad": 4,
+                "year": 2,
+                "description": "",
+                "correlativities": {
+                    "regularized": [3, 4],
+                    "approved": []
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
+        },
+        {
+            "sid": 20,
+            "index": 3,
+            "info": {
+                "name": "Desarrollo de Software",
+                "altname": "DdS",
+                "duration": 0,
+                "modality": 0,
+                "weeklyLoad": 8,
+                "year": 3,
+                "description": "",
+                "correlativities": {
+                    "regularized": [12, 9],
+                    "approved": [3, 4]
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
+        },
+        {
+            "sid": 28,
+            "index": 3,
+            "info": {
+                "name": "Simulacion",
+                "altname": "Sim",
+                "duration": 0,
+                "modality": 0,
+                "weeklyLoad": 6,
+                "year": 4,
+                "description": "",
+                "correlativities": {
+                    "regularized": [16],
+                    "approved": [10]
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
+        },
+        {
+            "sid": 36,
+            "index": 3,
+            "info": {
+                "name": "Sistemas de Gestion",
+                "altname": "SG",
+                "duration": 0,
+                "modality": 0,
+                "weeklyLoad": 6,
+                "year": 5,
+                "description": "",
+                "correlativities": {
+                    "regularized": [19, 30],
+                    "approved": [17]
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
+        },
+        {
+            "sid": 5,
+            "index": 4,
+            "info": {
+                "name": "Arquitectura de Computadoras",
+                "altname": "AdC",
+                "duration": 0,
+                "modality": 0,
+                "weeklyLoad": 4,
+                "year": 1,
+                "description": "Description lorem",
+                "correlativities": {
+                    "regularized": [],
+                    "approved": []
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
+        },
+        {
+            "sid": 13,
+            "index": 4,
+            "info": {
+                "name": "Ingles 1",
+                "altname": "IT1",
+                "duration": 1,
+                "modality": 0,
+                "weeklyLoad": 2,
+                "year": 2,
+                "description": "Recomendable hacerla libre",
+                "correlativities": {
+                    "regularized": [],
+                    "approved": []
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
+        },
+        {
+            "sid": 21,
+            "index": 4,
+            "info": {
+                "name": "Base de Datos",
+                "altname": "BD",
+                "duration": 0,
+                "modality": 0,
+                "weeklyLoad": 8,
+                "year": 3,
+                "description": "",
+                "correlativities": {
+                    "regularized": [11, 9],
+                    "approved": [3, 4]
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
+        },
+        {
+            "sid": 29,
+            "index": 4,
+            "info": {
+                "name": "Legislacion",
+                "altname": "Leg",
+                "duration": 0,
+                "modality": 0,
+                "weeklyLoad": 4,
+                "year": 4,
+                "description": "",
+                "correlativities": {
+                    "regularized": [8],
+                    "approved": []
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
+        },
+        {
+            "sid": 37,
+            "index": 4,
+            "info": {
+                "name": "Seguridad en los Sistemas de Informacion",
+                "altname": "SSI",
+                "duration": 0,
+                "modality": 0,
+                "weeklyLoad": 3,
+                "year": 5,
+                "description": "",
+                "correlativities": {
+                    "regularized": [24, 25],
+                    "approved": [20, 23]
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
+        },
+        {
+            "sid": 6,
+            "index": 5,
+            "info": {
+                "name": "Algebra y Geometria Analitica",
+                "altname": "AGA",
+                "duration": 1,
+                "modality": 0,
+                "weeklyLoad": 5,
+                "year": 1,
+                "description": "",
+                "correlativities": {
+                    "regularized": [],
+                    "approved": []
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
+        },
+        {
+            "sid": 14,
+            "index": 5,
+            "info": {
+                "name": "Fisica 2",
+                "altname": "F2",
+                "duration": 1,
+                "modality": 0,
+                "weeklyLoad": 5,
+                "year": 2,
+                "description": "",
+                "correlativities": {
+                    "regularized": [2, 7],
+                    "approved": []
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
+        },
+        {
+            "sid": 22,
+            "index": 5,
+            "info": {
+                "name": "Seminario Integrador",
+                "altname": "SI",
+                "duration": 0,
+                "modality": 0,
+                "weeklyLoad": 8,
+                "year": 3,
+                "description": "",
+                "correlativities": {
+                    "regularized": [9],
+                    "approved": [1, 4, 11, 12]
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
+        },
+        {
+            "sid": 30,
+            "index": 5,
+            "info": {
+                "name": "Investigacion Operativa",
+                "altname": "IO",
+                "duration": 0,
+                "modality": 0,
+                "weeklyLoad": 6,
+                "year": 4,
+                "description": "",
+                "correlativities": {
+                    "regularized": [16, 26],
+                    "approved": []
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
+        },
+        {
+            "sid": 7,
+            "index": 6,
+            "info": {
+                "name": "Fisica 1",
+                "altname": "F1",
+                "duration": 1,
+                "modality": 0,
+                "weeklyLoad": 5,
+                "year": 1,
+                "description": "",
+                "correlativities": {
+                    "regularized": [],
+                    "approved": []
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
+        },
+        {
+            "sid": 15,
+            "index": 6,
+            "info": {
+                "name": "Sistemas Operativos",
+                "altname": "SSOO",
+                "duration": 0,
+                "modality": 1,
+                "weeklyLoad": 8,
+                "year": 2,
+                "description": "",
+                "correlativities": {
+                    "regularized": [5],
+                    "approved": []
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
+        },
+        {
+            "sid": 23,
+            "index": 6,
+            "info": {
+                "name": "Comunicacion de Datos",
+                "altname": "CD",
+                "duration": 0,
+                "modality": 0,
+                "weeklyLoad": 8,
+                "year": 3,
+                "description": "",
+                "correlativities": {
+                    "regularized": [],
+                    "approved": [5, 7]
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
+        },
+        {
+            "sid": 31,
+            "index": 6,
+            "info": {
+                "name": "Tecnologias para la Automatizacion",
+                "altname": "TpA",
+                "duration": 0,
+                "modality": 0,
+                "weeklyLoad": 6,
+                "year": 4,
+                "description": "",
+                "correlativities": {
+                    "regularized": [14, 26],
+                    "approved": [10]
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
+        },
+        {
+            "sid": 8,
+            "index": 7,
+            "info": {
+                "name": "Ingenieria y Sociedad",
+                "altname": "IngSoc",
+                "duration": 0,
+                "modality": 0,
+                "weeklyLoad": 4,
+                "year": 1,
+                "description": "",
+                "correlativities": {
+                    "regularized": [],
+                    "approved": []
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
+        },
+        {
+            "sid": 16,
+            "index": 7,
+            "info": {
+                "name": "Probabilidad y estadistica",
+                "altname": "PyE",
+                "duration": 0,
+                "modality": 0,
+                "weeklyLoad": 6,
+                "year": 2,
+                "description": "",
+                "correlativities": {
+                    "regularized": [2, 6],
+                    "approved": []
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
+        },
+        {
+            "sid": 24,
+            "index": 7,
+            "info": {
+                "name": "Redes de Datos",
+                "altname": "RD",
+                "duration": 0,
+                "modality": 0,
+                "weeklyLoad": 8,
+                "year": 3,
+                "description": "",
+                "correlativities": {
+                    "regularized": [15, 23],
+                    "approved": []
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
+        },
+        {
+            "sid": 32,
+            "index": 7,
+            "info": {
+                "name": "Ciencia de Datos",
+                "altname": "CdD",
+                "duration": 0,
+                "modality": 0,
+                "weeklyLoad": 6,
+                "year": 4,
+                "description": "",
+                "correlativities": {
+                    "regularized": [28],
+                    "approved": [16, 21]
+                }
+            },
+            "personal": {
+                "qualification": 0,
+                "status": 0
+            }
         }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    },
-    {
-      "sid": 9,
-      "index": 0,
-      "info": {
-        "name": "Analisis de Sistemas de Informacion",
-        "altname": "ASI",
-        "duration": 1,
-        "modality": 0,
-        "weeklyLoad": 6,
-        "year": 2,
-        "description": "",
-        "correlativities": {
-          "regularized": [
-            1,
-            4
-          ],
-          "approved": []
-        }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    },
-    {
-      "sid": 17,
-      "index": 0,
-      "info": {
-        "name": "Diseño de Sistemas de Informacion",
-        "altname": "DSI",
-        "duration": 1,
-        "modality": 0,
-        "weeklyLoad": 6,
-        "year": 3,
-        "description": "",
-        "correlativities": {
-          "regularized": [
-            9,
-            12
-          ],
-          "approved": [
-            13,
-            4,
-            1
-          ]
-        }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    },
-    {
-      "sid": 25,
-      "index": 0,
-      "info": {
-        "name": "Administracion de Sistemas de Informacion",
-        "altname": "AdmSI",
-        "duration": 1,
-        "modality": 0,
-        "weeklyLoad": 6,
-        "year": 4,
-        "description": "",
-        "correlativities": {
-          "regularized": [
-            19,
-            17
-          ],
-          "approved": [
-            9
-          ]
-        }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    },
-    {
-      "sid": 33,
-      "index": 0,
-      "info": {
-        "name": "Proyecto Final",
-        "altname": "PF",
-        "duration": 1,
-        "modality": 0,
-        "weeklyLoad": 6,
-        "year": 5,
-        "description": "",
-        "correlativities": {
-          "regularized": [
-            27,
-            25,
-            24
-          ],
-          "approved": [
-            18,
-            20,
-            17
-          ]
-        }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    },
-    {
-      "sid": 2,
-      "index": 1,
-      "info": {
-        "name": "Analisis Matematico 1",
-        "altname": "AM1",
-        "duration": 1,
-        "modality": 0,
-        "weeklyLoad": 5,
-        "year": 1,
-        "description": "",
-        "correlativities": {
-          "regularized": [],
-          "approved": []
-        }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    },
-    {
-      "sid": 10,
-      "index": 1,
-      "info": {
-        "name": "Analisis Matematico 2",
-        "altname": "AM2",
-        "duration": 1,
-        "modality": 0,
-        "weeklyLoad": 5,
-        "year": 2,
-        "description": "",
-        "correlativities": {
-          "regularized": [
-            2,
-            6
-          ],
-          "approved": []
-        }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    },
-    {
-      "sid": 18,
-      "index": 1,
-      "info": {
-        "name": "Ingles 2",
-        "altname": "IT2",
-        "duration": 1,
-        "modality": 0,
-        "weeklyLoad": 2,
-        "year": 3,
-        "description": "",
-        "correlativities": {
-          "regularized": [
-            13
-          ],
-          "approved": []
-        }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    },
-    {
-      "sid": 26,
-      "index": 1,
-      "info": {
-        "name": "Analisis Numerico",
-        "altname": "AN",
-        "duration": 0,
-        "modality": 0,
-        "weeklyLoad": 6,
-        "year": 4,
-        "description": "",
-        "correlativities": {
-          "regularized": [
-            10
-          ],
-          "approved": [
-            2,
-            6
-          ]
-        }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    },
-    {
-      "sid": 34,
-      "index": 1,
-      "info": {
-        "name": "Inteligencia Artificial",
-        "altname": "IA",
-        "duration": 0,
-        "modality": 0,
-        "weeklyLoad": 6,
-        "year": 5,
-        "description": "",
-        "correlativities": {
-          "regularized": [
-            28
-          ],
-          "approved": [
-            16,
-            26
-          ]
-        }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    },
-    {
-      "sid": 3,
-      "index": 2,
-      "info": {
-        "name": "Logica y Estructuras Discretas",
-        "altname": "LyED",
-        "duration": 1,
-        "modality": 0,
-        "weeklyLoad": 3,
-        "year": 1,
-        "description": "",
-        "correlativities": {
-          "regularized": [],
-          "approved": []
-        }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    },
-    {
-      "sid": 11,
-      "index": 2,
-      "info": {
-        "name": "Sintaxis y Semantica de los Lenguajes",
-        "altname": "SySL",
-        "duration": 1,
-        "modality": 0,
-        "weeklyLoad": 4,
-        "year": 2,
-        "description": "",
-        "correlativities": {
-          "regularized": [
-            3,
-            4
-          ],
-          "approved": []
-        }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    },
-    {
-      "sid": 19,
-      "index": 2,
-      "info": {
-        "name": "Economia",
-        "altname": "ECO",
-        "duration": 0,
-        "modality": 0,
-        "weeklyLoad": 6,
-        "year": 3,
-        "description": "",
-        "correlativities": {
-          "regularized": [],
-          "approved": [
-            2,
-            6
-          ]
-        }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    },
-    {
-      "sid": 27,
-      "index": 2,
-      "info": {
-        "name": "Ingenieria y Calidad de Software",
-        "altname": "IyCS",
-        "duration": 0,
-        "modality": 0,
-        "weeklyLoad": 6,
-        "year": 4,
-        "description": "",
-        "correlativities": {
-          "regularized": [
-            21,
-            20,
-            17
-          ],
-          "approved": [
-            11,
-            12
-          ]
-        }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    },
-    {
-      "sid": 35,
-      "index": 2,
-      "info": {
-        "name": "Gestion Gerencial",
-        "altname": "GC",
-        "duration": 0,
-        "modality": 0,
-        "weeklyLoad": 6,
-        "year": 5,
-        "description": "",
-        "correlativities": {
-          "regularized": [
-            29,
-            25
-          ],
-          "approved": [
-            19
-          ]
-        }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    },
-    {
-      "sid": 4,
-      "index": 3,
-      "info": {
-        "name": "Algoritmos y Estructuras de Datos",
-        "altname": "AyED",
-        "duration": 1,
-        "modality": 0,
-        "weeklyLoad": 5,
-        "year": 1,
-        "description": "",
-        "correlativities": {
-          "regularized": [],
-          "approved": []
-        }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    },
-    {
-      "sid": 12,
-      "index": 3,
-      "info": {
-        "name": "Paradigmas de Programacion",
-        "altname": "PdP",
-        "duration": 1,
-        "modality": 0,
-        "weeklyLoad": 4,
-        "year": 2,
-        "description": "",
-        "correlativities": {
-          "regularized": [
-            3,
-            4
-          ],
-          "approved": []
-        }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    },
-    {
-      "sid": 20,
-      "index": 3,
-      "info": {
-        "name": "Desarrollo de Software",
-        "altname": "DdS",
-        "duration": 0,
-        "modality": 0,
-        "weeklyLoad": 8,
-        "year": 3,
-        "description": "",
-        "correlativities": {
-          "regularized": [
-            12,
-            9
-          ],
-          "approved": [
-            3,
-            4
-          ]
-        }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    },
-    {
-      "sid": 28,
-      "index": 3,
-      "info": {
-        "name": "Simulacion",
-        "altname": "Sim",
-        "duration": 0,
-        "modality": 0,
-        "weeklyLoad": 6,
-        "year": 4,
-        "description": "",
-        "correlativities": {
-          "regularized": [
-            16
-          ],
-          "approved": [
-            10
-          ]
-        }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    },
-    {
-      "sid": 36,
-      "index": 3,
-      "info": {
-        "name": "Sistemas de Gestion",
-        "altname": "SG",
-        "duration": 0,
-        "modality": 0,
-        "weeklyLoad": 6,
-        "year": 5,
-        "description": "",
-        "correlativities": {
-          "regularized": [
-            19,
-            30
-          ],
-          "approved": [
-            17
-          ]
-        }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    },
-    {
-      "sid": 5,
-      "index": 4,
-      "info": {
-        "name": "Arquitectura de Computadoras",
-        "altname": "AdC",
-        "duration": 0,
-        "modality": 0,
-        "weeklyLoad": 4,
-        "year": 1,
-        "description": "Description lorem",
-        "correlativities": {
-          "regularized": [],
-          "approved": []
-        }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    },
-    {
-      "sid": 13,
-      "index": 4,
-      "info": {
-        "name": "Ingles 1",
-        "altname": "IT1",
-        "duration": 1,
-        "modality": 0,
-        "weeklyLoad": 2,
-        "year": 2,
-        "description": "Recomendable hacerla libre",
-        "correlativities": {
-          "regularized": [],
-          "approved": []
-        }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    },
-    {
-      "sid": 21,
-      "index": 4,
-      "info": {
-        "name": "Base de Datos",
-        "altname": "BD",
-        "duration": 0,
-        "modality": 0,
-        "weeklyLoad": 8,
-        "year": 3,
-        "description": "",
-        "correlativities": {
-          "regularized": [
-            11,
-            9
-          ],
-          "approved": [
-            3,
-            4
-          ]
-        }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    },
-    {
-      "sid": 29,
-      "index": 4,
-      "info": {
-        "name": "Legislacion",
-        "altname": "Leg",
-        "duration": 0,
-        "modality": 0,
-        "weeklyLoad": 4,
-        "year": 4,
-        "description": "",
-        "correlativities": {
-          "regularized": [
-            8
-          ],
-          "approved": []
-        }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    },
-    {
-      "sid": 37,
-      "index": 4,
-      "info": {
-        "name": "Seguridad en los Sistemas de Informacion",
-        "altname": "SSI",
-        "duration": 0,
-        "modality": 0,
-        "weeklyLoad": 3,
-        "year": 5,
-        "description": "",
-        "correlativities": {
-          "regularized": [
-            24,
-            25
-          ],
-          "approved": [
-            20,
-            23
-          ]
-        }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    },
-    {
-      "sid": 6,
-      "index": 5,
-      "info": {
-        "name": "Algebra y Geometria Analitica",
-        "altname": "AGA",
-        "duration": 1,
-        "modality": 0,
-        "weeklyLoad": 5,
-        "year": 1,
-        "description": "",
-        "correlativities": {
-          "regularized": [],
-          "approved": []
-        }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    },
-    {
-      "sid": 14,
-      "index": 5,
-      "info": {
-        "name": "Fisica 2",
-        "altname": "F2",
-        "duration": 1,
-        "modality": 0,
-        "weeklyLoad": 5,
-        "year": 2,
-        "description": "",
-        "correlativities": {
-          "regularized": [
-            2,
-            7
-          ],
-          "approved": []
-        }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    },
-    {
-      "sid": 22,
-      "index": 5,
-      "info": {
-        "name": "Seminario Integrador",
-        "altname": "SI",
-        "duration": 0,
-        "modality": 0,
-        "weeklyLoad": 8,
-        "year": 3,
-        "description": "",
-        "correlativities": {
-          "regularized": [
-            15
-          ],
-          "approved": [
-            5,
-            13,
-            9,
-            11
-          ]
-        }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    },
-    {
-      "sid": 30,
-      "index": 5,
-      "info": {
-        "name": "Investigacion Operativa",
-        "altname": "IO",
-        "duration": 0,
-        "modality": 0,
-        "weeklyLoad": 6,
-        "year": 4,
-        "description": "",
-        "correlativities": {
-          "regularized": [
-            16,
-            26
-          ],
-          "approved": []
-        }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    },
-    {
-      "sid": 7,
-      "index": 6,
-      "info": {
-        "name": "Fisica 1",
-        "altname": "F1",
-        "duration": 1,
-        "modality": 0,
-        "weeklyLoad": 5,
-        "year": 1,
-        "description": "",
-        "correlativities": {
-          "regularized": [],
-          "approved": []
-        }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    },
-    {
-      "sid": 15,
-      "index": 6,
-      "info": {
-        "name": "Sistemas Operativos",
-        "altname": "SSOO",
-        "duration": 0,
-        "modality": 1,
-        "weeklyLoad": 8,
-        "year": 2,
-        "description": "",
-        "correlativities": {
-          "regularized": [
-            5
-          ],
-          "approved": []
-        }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    },
-    {
-      "sid": 23,
-      "index": 6,
-      "info": {
-        "name": "Comunicacion de Datos",
-        "altname": "CD",
-        "duration": 0,
-        "modality": 0,
-        "weeklyLoad": 8,
-        "year": 3,
-        "description": "",
-        "correlativities": {
-          "regularized": [],
-          "approved": [
-            5,
-            7
-          ]
-        }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    },
-    {
-      "sid": 31,
-      "index": 6,
-      "info": {
-        "name": "Tecnologias para la Automatizacion",
-        "altname": "TpA",
-        "duration": 0,
-        "modality": 0,
-        "weeklyLoad": 6,
-        "year": 4,
-        "description": "",
-        "correlativities": {
-          "regularized": [
-            14,
-            26
-          ],
-          "approved": [
-            10
-          ]
-        }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    },
-    {
-      "sid": 8,
-      "index": 7,
-      "info": {
-        "name": "Ingenieria y Sociedad",
-        "altname": "IngSoc",
-        "duration": 0,
-        "modality": 0,
-        "weeklyLoad": 4,
-        "year": 1,
-        "description": "",
-        "correlativities": {
-          "regularized": [],
-          "approved": []
-        }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    },
-    {
-      "sid": 16,
-      "index": 7,
-      "info": {
-        "name": "Probabilidad y estadistica",
-        "altname": "PyE",
-        "duration": 0,
-        "modality": 0,
-        "weeklyLoad": 6,
-        "year": 2,
-        "description": "",
-        "correlativities": {
-          "regularized": [
-            2,
-            6
-          ],
-          "approved": []
-        }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    },
-    {
-      "sid": 24,
-      "index": 7,
-      "info": {
-        "name": "Redes de Datos",
-        "altname": "RD",
-        "duration": 0,
-        "modality": 0,
-        "weeklyLoad": 8,
-        "year": 3,
-        "description": "",
-        "correlativities": {
-          "regularized": [
-            15,
-            23
-          ],
-          "approved": []
-        }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    },
-    {
-      "sid": 32,
-      "index": 7,
-      "info": {
-        "name": "Ciencia de Datos",
-        "altname": "CdD",
-        "duration": 0,
-        "modality": 0,
-        "weeklyLoad": 6,
-        "year": 4,
-        "description": "",
-        "correlativities": {
-          "regularized": [
-            28
-          ],
-          "approved": [
-            16,
-            21
-          ]
-        }
-      },
-      "personal": {
-        "qualification": 0,
-        "status": 0
-      }
-    }
-  ]
+    ]
 }

--- a/public/data/careers/Ing en sistemas UTN.json
+++ b/public/data/careers/Ing en sistemas UTN.json
@@ -517,7 +517,7 @@
                 "altname": "SSI",
                 "duration": 0,
                 "modality": 0,
-                "weeklyLoad": 3,
+                "weeklyLoad": 6,
                 "year": 5,
                 "description": "",
                 "correlativities": {
@@ -601,7 +601,7 @@
                 "altname": "IO",
                 "duration": 0,
                 "modality": 0,
-                "weeklyLoad": 6,
+                "weeklyLoad": 8,
                 "year": 4,
                 "description": "",
                 "correlativities": {


### PR DESCRIPTION
Fueron actualizadas las correlativas y horas semanales de algunas materias.
En AN:
- Regularizadas: `PyE` -> `AM2`

En Seminario:
- Regularizadas: `SSOO` -> `ASI`
- Aprobadas: `AdC, IT1, ASI, SySL` -> `SyPN, AyED, SySL, PdP`

En IO
- Horas semanales: `6` -> `8`

En SSI:
- Horas semanales: `3` -> `6`


Todos estos cambios fueron hechos basado en el folleto de Franja Morada que se puede [encontrar acá](https://drive.google.com/drive/folders/1pLPS88peussSzaRrf5D0wOykA12HSPwi)